### PR TITLE
add bounds detection for google results

### DIFF
--- a/lib/geocoder/results/google.rb
+++ b/lib/geocoder/results/google.rb
@@ -120,19 +120,30 @@ module Geocoder::Result
     def precision
       geometry['location_type'] if geometry
     end
-    
+
     def partial_match
       @data['partial_match']
     end
-    
+
     def place_id
       @data['place_id']
-    end  
+    end
 
     def viewport
-      viewport = geometry['viewport'] || fail
-      south, west = %w(lat lng).map { |c| viewport['southwest'][c] }
-      north, east = %w(lat lng).map { |c| viewport['northeast'][c] }
+      bounding_box_from geometry['viewport']
+    end
+
+    def bounds
+      puts geometry
+      bounding_box_from geometry['bounds']
+    end
+
+    private
+
+    def bounding_box_from(box)
+      fail unless box
+      south, west = %w(lat lng).map { |c| box[c] }
+      north, east = %w(lat lng).map { |c| box[c] }
       [south, west, north, east]
     end
   end

--- a/test/fixtures/google_new_york
+++ b/test/fixtures/google_new_york
@@ -1,0 +1,64 @@
+{
+  "status": "OK",
+  "results": [ {
+    "address_components": [
+      {
+        "long_name": "New York",
+        "short_name": "New York",
+        "types": [
+          "locality",
+          "political"
+        ]
+      },
+      {
+        "long_name": "New York",
+        "short_name": "NY",
+        "types": [
+          "administrative_area_level_1",
+          "political"
+        ]
+      },
+      {
+        "long_name": "United States",
+        "short_name": "US",
+        "types": [
+          "country",
+          "political"
+        ]
+      }
+    ],
+    "formatted_address": "New York, NY, USA",
+    "geometry": {
+      "bounds": {
+        "northeast": {
+          "lat": 40.9175771,
+          "lng": -73.7002721
+        },
+        "southwest": {
+          "lat": 40.4773991,
+          "lng": -74.2590899
+        }
+      },
+      "location": {
+        "lat": 40.7127837,
+        "lng": -74.0059413
+      },
+      "location_type": "APPROXIMATE",
+      "viewport": {
+        "northeast": {
+          "lat": 40.9152555,
+          "lng": -73.7002721
+        },
+        "southwest": {
+          "lat": 40.4960439,
+          "lng": -74.2557349
+        }
+      }
+    },
+    "place_id": "ChIJOwg_06VPwokRYv534QaPC8g",
+    "types": [
+      "locality",
+      "political"
+    ]
+  } ]
+}

--- a/test/unit/lookups/google_test.rb
+++ b/test/unit/lookups/google_test.rb
@@ -48,6 +48,12 @@ class GoogleTest < GeocoderTestCase
       result.viewport
   end
 
+  def test_google_bounds
+    result = Geocoder.search("new york").first
+    assert_equal [40.4773991, -74.2590899, 40.9175771, -73.7002721],
+      result.bounds
+  end
+
   def test_google_query_url_contains_bounds
     lookup = Geocoder::Lookup::Google.new
     url = lookup.query_url(Geocoder::Query.new(


### PR DESCRIPTION
some google geocoding requests have bounds within the result.  add a
helper to extract these.